### PR TITLE
[Frontend]Home画面を実装

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -12,5 +12,5 @@
 			}
 		}
 	],
-	"tailwindStylesheet": "./src/routes/layout.css"
+	"tailwindStylesheet": "./src/app.css"
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,9 @@
+@import "tailwindcss";
+ 
+@plugin '@tailwindcss/forms';
+@plugin '@tailwindcss/typography';
+
+@theme {
+  --color-primary: #f15922; 
+  --color-secondary: #f1eac3; 
+}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,9 +1,9 @@
-@import "tailwindcss";
- 
+@import 'tailwindcss';
+
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
 
 @theme {
-  --color-primary: #f15922; 
-  --color-secondary: #f1eac3; 
+	--color-primary: #f15922;
+	--color-secondary: #f1eac3;
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,9 +1,29 @@
 <script lang="ts">
-	import './layout.css';
-	import favicon from '$lib/assets/favicon.svg';
+    import '../app.css';
 
-	let { children } = $props();
+    let { children } = $props();
 </script>
 
-<svelte:head><link rel="icon" href={favicon} /></svelte:head>
-{@render children()}
+<div class="min-h-screen bg-gray-50 flex flex-col font-sans">
+    
+    <header class="w-full p-4 flex justify-center border-b border-gray-200 bg-white/50 backdrop-blur-sm sticky top-0 z-10">
+        <nav class="flex flex-wrap gap-4 items-center justify-center">
+            <a href="/skills" class="px-4 py-2 hover:text-primary transition-colors">スキル</a>
+            <a href="/career" class="px-4 py-2 hover:text-primary transition-colors">経歴</a>
+            <a href="/products" class="px-4 py-2 hover:text-primary transition-colors">開発実績</a>
+            
+            <a href="/login" class="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition-opacity">
+                ログイン
+            </a>
+        </nav>
+    </header>
+
+    <main class="flex-1 flex flex-col justify-center items-center p-4 w-full max-w-4xl mx-auto">
+        {@render children()}
+    </main>
+
+    <footer class="p-4 text-center text-gray-400 text-sm">
+        &copy; 2026 marumo333 Portfolio
+    </footer>
+
+</div>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
 		class="sticky top-0 z-10 flex w-full justify-center border-b border-gray-200 bg-white/50 p-4 backdrop-blur-sm"
 	>
 		<nav class="flex flex-wrap items-center justify-center gap-4">
+			<a href={resolve('/')} class="px-4 py-2 transition-colors hover:text-primary">Home</a>
 			<a href={resolve('/skills')} class="px-4 py-2 transition-colors hover:text-primary">スキル</a>
 			<a href={resolve('/career')} class="px-4 py-2 transition-colors hover:text-primary">経歴</a>
 			<a href={resolve('/products')} class="px-4 py-2 transition-colors hover:text-primary"

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,29 +1,33 @@
 <script lang="ts">
-    import '../app.css';
+	import '../app.css';
+	import { resolve } from '$app/paths';
 
-    let { children } = $props();
+	let { children } = $props();
 </script>
 
-<div class="min-h-screen bg-gray-50 flex flex-col font-sans">
-    
-    <header class="w-full p-4 flex justify-center border-b border-gray-200 bg-white/50 backdrop-blur-sm sticky top-0 z-10">
-        <nav class="flex flex-wrap gap-4 items-center justify-center">
-            <a href="/skills" class="px-4 py-2 hover:text-primary transition-colors">スキル</a>
-            <a href="/career" class="px-4 py-2 hover:text-primary transition-colors">経歴</a>
-            <a href="/products" class="px-4 py-2 hover:text-primary transition-colors">開発実績</a>
-            
-            <a href="/login" class="px-4 py-2 bg-primary text-white rounded hover:bg-opacity-90 transition-opacity">
-                ログイン
-            </a>
-        </nav>
-    </header>
+<div class="flex min-h-screen flex-col bg-gray-50 font-sans">
+	<header
+		class="sticky top-0 z-10 flex w-full justify-center border-b border-gray-200 bg-white/50 p-4 backdrop-blur-sm"
+	>
+		<nav class="flex flex-wrap items-center justify-center gap-4">
+			<a href={resolve('/skills')} class="px-4 py-2 transition-colors hover:text-primary">スキル</a>
+			<a href={resolve('/career')} class="px-4 py-2 transition-colors hover:text-primary">経歴</a>
+			<a href={resolve('/products')} class="px-4 py-2 transition-colors hover:text-primary"
+				>開発実績</a
+			>
 
-    <main class="flex-1 flex flex-col justify-center items-center p-4 w-full max-w-4xl mx-auto">
-        {@render children()}
-    </main>
+			<a
+				href={resolve('/login')}
+				class="hover:bg-opacity-90 rounded bg-primary px-4 py-2 text-white transition-opacity"
+			>
+				ログイン
+			</a>
+		</nav>
+	</header>
 
-    <footer class="p-4 text-center text-gray-400 text-sm">
-        &copy; 2026 marumo333 Portfolio
-    </footer>
+	<main class="mx-auto flex w-full max-w-4xl flex-1 flex-col items-center justify-center p-4">
+		{@render children()}
+	</main>
 
+	<footer class="p-4 text-center text-sm text-gray-400">&copy; 2026 marumo333 Portfolio</footer>
 </div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,2 +1,14 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+    //ホーム画面は静的なため、記述なし
+</script>
+
+   <section class="text-center max-w-2xl"> 
+      <h1 class="text-4xl md:text-4xl lg:text-5xl font-bold text-primary mb-4">
+          marumo333's Portfolio
+      </h1>
+      
+      <p class="text-base md:text-lg lg:text-xl text-gray-700 leading-relaxed">    
+        こちらはmarumo333のスキル・経歴・開発実績が参照できるportfolioのwebアプリです。
+        ログインを行うことで、RAGを用いたportfolio記載の内容に限定したchatが可能です。
+      </p>
+   </section>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-    //ホーム画面は静的なため、記述なし
+	//ホーム画面は静的なため、記述なし
 </script>
 
-   <section class="text-center max-w-2xl"> 
-      <h1 class="text-4xl md:text-4xl lg:text-5xl font-bold text-primary mb-4">
-          marumo333's Portfolio
-      </h1>
-      
-      <p class="text-base md:text-lg lg:text-xl text-gray-700 leading-relaxed">    
-        こちらはmarumo333のスキル・経歴・開発実績が参照できるportfolioのwebアプリです。
-        ログインを行うことで、RAGを用いたportfolio記載の内容に限定したchatが可能です。
-      </p>
-   </section>
+<section class="max-w-2xl text-center">
+	<h1 class="mb-4 text-4xl font-bold text-primary md:text-4xl lg:text-5xl">
+		marumo333's Portfolio
+	</h1>
+
+	<p class="text-base leading-relaxed text-gray-700 md:text-lg lg:text-xl">
+		こちらはmarumo333のスキル・経歴・開発実績が参照できるportfolioのwebアプリです。
+		ログインを行うことで、RAGを用いたportfolio記載の内容に限定したchatが可能です。
+	</p>
+</section>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -8,7 +8,7 @@
 	</h1>
 
 	<p class="text-base leading-relaxed text-gray-700 md:text-lg lg:text-xl">
-		こちらはmarumo333のスキル・経歴・開発実績が参照できるportfolioのwebアプリです。
-		ログインを行うことで、RAGを用いたportfolio記載の内容に限定したchatが可能です。
+		marumo333のスキル・経歴・開発実績が参照できるportfolioのwebアプリ<br />
+		RAGを用いたportfolio記載の内容に限定したchatが可能(ログインのみ)
 	</p>
 </section>

--- a/frontend/src/routes/career/+page.svelte
+++ b/frontend/src/routes/career/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	// 経歴ページ
+</script>
+
+<section class="w-full max-w-2xl text-center">
+	<h1 class="mb-4 text-3xl font-bold text-primary md:text-4xl">経歴</h1>
+	<p class="text-base text-gray-700 md:text-lg">準備中</p>
+</section>

--- a/frontend/src/routes/layout.css
+++ b/frontend/src/routes/layout.css
@@ -1,3 +1,0 @@
-@import 'tailwindcss';
-@plugin '@tailwindcss/forms';
-@plugin '@tailwindcss/typography';

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	// ログインページ
+</script>
+
+<section class="w-full max-w-2xl text-center">
+	<h1 class="mb-4 text-3xl font-bold text-primary md:text-4xl">ログイン</h1>
+	<p class="text-base text-gray-700 md:text-lg">準備中</p>
+</section>

--- a/frontend/src/routes/products/+page.svelte
+++ b/frontend/src/routes/products/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	// 開発実績ページ
+</script>
+
+<section class="w-full max-w-2xl text-center">
+	<h1 class="mb-4 text-3xl font-bold text-primary md:text-4xl">開発実績</h1>
+	<p class="text-base text-gray-700 md:text-lg">準備中</p>
+</section>

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	// スキルページ
+</script>
+
+<section class="w-full max-w-2xl text-center">
+	<h1 class="mb-4 text-3xl font-bold text-primary md:text-4xl">スキル</h1>
+	<p class="text-base text-gray-700 md:text-lg">準備中</p>
+</section>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,9 +4,9 @@ import tailwindcss from '@tailwindcss/vite'; // ← これが必要です！
 
 export default defineConfig({
 	plugins: [
-        sveltekit(),
-        tailwindcss() // ← これがないとTailwindが動きません
-    ],
+		sveltekit(),
+		tailwindcss() // ← これがないとTailwindが動きません
+	],
 	server: {
 		proxy: {
 			'/api': {


### PR DESCRIPTION
- ホーム画面（/）にヒーローセクションを実装                                                                                               
   - 経歴・スキル・開発実績・ログインの暫定ページを作成                                                                                      
   - CSSを `app.css` に統一し、`layout.css` を削除                                                                                           
                                                                                                                                             
   ## Test plan                                                                                                                              
   - [ ] PCサイズでレイアウトが崩れないこと                                                                                                  
   - [ ] SPサイズでレイアウトが崩れないこと                                                                                                  
   - [ ] 各ナビゲーションリンクが正常に動作すること                                                                                          
   - [ ] `npm run lint` がエラーなく通ること 